### PR TITLE
Add cumulative delta example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1413,3 +1413,8 @@ side = bm.get_order_side(mbo_order_book, order_id)
 ```
 
 This function returns order side, True if bid, otherwise False. Throw `ValueError` if there is no such order.
+
+### Data arrays
+
+You can maintain arrays of collected prices, volumes, or any other data using standard Python lists. These arrays help build custom indicators or export data for further analysis.
+

--- a/examples/cumulative_delta.py
+++ b/examples/cumulative_delta.py
@@ -1,0 +1,52 @@
+import bookmap as bm
+
+alias_to_cvd = {}
+alias_to_indicator_id = {}
+request_ids = {}
+next_req_id = 1
+
+
+def handle_subscribe_instrument(addon, alias, full_name, is_crypto, pips,
+                                size_multiplier, instrument_multiplier,
+                                supported_features):
+    global next_req_id
+    alias_to_cvd[alias] = 0
+    request_ids[alias] = next_req_id
+    bm.register_indicator(addon, alias, next_req_id,
+                          "Cumulative Delta", "BOTTOM")
+    next_req_id += 1
+
+
+def handle_indicator_response(addon, request_id, indicator_id):
+    for alias, req in request_ids.items():
+        if req == request_id:
+            alias_to_indicator_id[alias] = indicator_id
+            break
+
+
+def handle_trades(addon, alias, price, size, is_otc, is_bid,
+                  is_execution_start, is_execution_end,
+                  aggressor_order_id, passive_order_id):
+    if alias not in alias_to_indicator_id:
+        return
+    if is_bid:
+        alias_to_cvd[alias] += size
+    else:
+        alias_to_cvd[alias] -= size
+    bm.add_point(addon, alias, alias_to_indicator_id[alias],
+                 alias_to_cvd[alias])
+
+
+def handle_unsubscribe_instrument(addon, alias):
+    alias_to_cvd.pop(alias, None)
+    alias_to_indicator_id.pop(alias, None)
+    request_ids.pop(alias, None)
+
+
+if __name__ == "__main__":
+    addon = bm.create_addon()
+    bm.add_indicator_response_handler(addon, handle_indicator_response)
+    bm.add_trades_handler(addon, handle_trades)
+    bm.start_addon(addon, handle_subscribe_instrument,
+                   handle_unsubscribe_instrument)
+    bm.wait_until_addon_is_turned_off(addon)


### PR DESCRIPTION
## Summary
- document usage of data arrays
- add a new Cumulative Delta example script

## Testing
- `PYTHONPATH=client-rpc pytest -q client-rpc/tests`

------
https://chatgpt.com/codex/tasks/task_e_684404d90ce0832aacdcac5b63075a20