### PR TITLE
Add py_compile test for example

### DIFF
--- a/client-rpc/tests/test_examples_compile.py
+++ b/client-rpc/tests/test_examples_compile.py
@@ -1,0 +1,12 @@
+import unittest
+import os
+import py_compile
+
+class ExamplesCompileTest(unittest.TestCase):
+    def test_local_reversal_indicator_compiles(self):
+        example_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), '..', '..', 'examples', 'local_reversal_indicator.py')
+        )
+        if not os.path.exists(example_path):
+            self.skipTest(f"{example_path} not found")
+        py_compile.compile(example_path, doraise=True)


### PR DESCRIPTION
## Summary
- add unittest to compile `examples/local_reversal_indicator.py`

## Testing
- `python3 -m unittest discover client-rpc/tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684404da82ac832aa045768230dbde73